### PR TITLE
修改分页中未提及先排序再分页的说明

### DIFF
--- a/docs/guide/paging.md
+++ b/docs/guide/paging.md
@@ -26,6 +26,17 @@ var list = fsql.Select<Topic>()
     .Tolist();
 ```
 
+> 注意： 上述例子是对单表进行的查询。如果您正在对多表进行查询，必须要在Count之前先进行排序，防止出现不可理解的分页情况。当然，即使是单表，为了防止让分页的次序明确，也建议先排序。
+
+```csharp
+var list = fsql.Select<Topic>()
+    .Where(a => a.Id > 10)
+    .OrderBy(a => a.MsgTime)
+    .Count(out var total) //总记录数量
+    .Page(1, 20)
+    .Tolist();
+```
+
 ## 优化
 
 SqlServer 2012 以前的版本，使用 row_number 分页；


### PR DESCRIPTION
分页是在排序的前提下进行的，有些数据库不明确要求，但是，排序的结果在多表的情况下，将是错乱的（特别是有左连接且数据库默认使用右边的表进行排序的情况下）。